### PR TITLE
sched_class: Make subject modifiers optional, fix TypeError in __toString__

### DIFF
--- a/attendance_manager/sched_class.py
+++ b/attendance_manager/sched_class.py
@@ -31,5 +31,8 @@ class SchedClass:
             self.date.isoformat(), self.subject +
             str(self.subject_modifier
                 if self.subject_modifier != None
-                else ''), self.class_identifier
+                else ''),
+            (self.class_identifier
+                if self.class_identifier != None
+                else '')
         ])


### PR DESCRIPTION
Fixes #1.
Fix `TypeError` in `join` when `class_identifier` is `NoneType`.

Also fixes a typo.